### PR TITLE
Fixed prototype pollution issue

### DIFF
--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -24,7 +24,7 @@ var adaptivePaymentsMethods = [
 
 function merge(a, b) {
     for (var p in b) {
-        if (p === '__proto__') continue;
+        if (p === '__proto__' || 'constructor') continue;
         try {
             if (b[p].constructor === Object) {
                 a[p] = merge(a[p], b[p]);

--- a/lib/paypal-adaptive.js
+++ b/lib/paypal-adaptive.js
@@ -24,6 +24,7 @@ var adaptivePaymentsMethods = [
 
 function merge(a, b) {
     for (var p in b) {
+        if (p === '__proto__') continue;
         try {
             if (b[p].constructor === Object) {
                 a[p] = merge(a[p], b[p]);


### PR DESCRIPTION
Fixed prototype pollution issue caused by `JSON.parse()` transforming `__proto__` into a normal key in the new object.